### PR TITLE
Add 'preserve' configuration option

### DIFF
--- a/types/mempatch.cpp
+++ b/types/mempatch.cpp
@@ -32,6 +32,9 @@ public:
 		for (auto bit : info.vecVerify) {
 			this->vecVerify.append(bit);
 		}
+		for (auto bit : info.vecPreserve) {
+			this->vecPreserve.append(bit);
+		}
 		this->pAddress = pAddress + (info.offset);
 	}
 	
@@ -49,6 +52,16 @@ public:
 		SourceHook::SetMemAccess((void*) this->pAddress, vecPatch.length() * sizeof(uint8_t),
 				SH_MEM_READ | SH_MEM_WRITE | SH_MEM_EXEC);
 		ByteVectorWrite(vecPatch, (uint8_t*) pAddress);
+		
+		// 
+		for (size_t i = 0; i < vecPatch.length(); i++) {
+			uint8_t preserveBits = 0;
+			if (i < vecPreserve.length()) {
+				preserveBits = vecPreserve[i];
+			}
+			*((uint8_t*) pAddress + i) = (vecPatch[i] & ~preserveBits) | (vecRestore[i] & preserveBits);
+		}
+		
 		return true;
 	}
 	
@@ -76,7 +89,7 @@ public:
 	}
 	
 	uintptr_t pAddress;
-	ByteVector vecPatch, vecRestore, vecVerify;
+	ByteVector vecPatch, vecRestore, vecVerify, vecPreserve;
 };
 
 void MemoryPatchHandler::OnHandleDestroy(HandleType_t type, void* object) {

--- a/userconf/mempatches.cpp
+++ b/userconf/mempatches.cpp
@@ -139,6 +139,8 @@ SMCResult MemPatchGameConfig::ReadSMC_KeyValue(const SMCStates *states, const ch
 			g_CurrentPatchInfo->vecPatch = ByteVectorFromString(value);
 		} else if (!strcmp(key, "verify")) {
 			g_CurrentPatchInfo->vecVerify = ByteVectorFromString(value);
+		} else if (!strcmp(key, "preserve")) {
+			g_CurrentPatchInfo->vecPreserve = ByteVectorFromString(value);
 		}
 		break;
 	default:

--- a/userconf/mempatches.h
+++ b/userconf/mempatches.h
@@ -24,7 +24,7 @@ public:
 	public:
 		ke::AString signature;
 		size_t offset;
-		ByteVector vecPatch, vecVerify;
+		ByteVector vecPatch, vecVerify, vecPreserve;
 	};
 	
 	enum ParseState {


### PR DESCRIPTION
~~⚠️ This PR hasn't been personally tested.  It compiles and the logic looks right, but I don't have any use-cases I'm able to test against.~~

Here's a [compiled build](https://github.com/nosoop/SMExt-SourceScramble/files/6525316/preserves.zip) for those that do intend to test it.

----

Given the following instruction:
```
f3 0f 59 15 00 00 00 00    mulss  xmm2,DWORD PTR ds:0x0
```

We would like to patch this while preserving the XMM register (which is wildcarded out for future proofing).

```
f3 0f 59 ?? 00 00 00 00    mulss  xmm??,DWORD PTR ds:0x0
```

While this is totally doable for unmanaged patches (from Source Scramble's perspective &mdash; plugins can read, patch, then restore certain bytes), managed ones aren't capable of this.

This PR adds a new key `preserve`, which takes a bitmask indicating bits to preserve from the pre- to post- patch states.  This allows config writers to copy over full bytes:

```
"preserve" "\x00\x00\x00\xFF\x00\x00\x00\x00"
```

or even partial

```
"preserve" "\x00\x00\x00\xF0\x00\x00\x00\x00"
```

This PR is a successor to, and closes #3.