### PR TITLE
Build releases against Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-20.04
           - windows-latest
         include:
           - meta_branch: "1.11-dev"
             sm_branch: "1.11-dev"
             spcomp_version: "1.11.x"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             os_short: linux
             package_ext: tar.gz
 

--- a/.github/workflows/pull-request-ci-test.yml
+++ b/.github/workflows/pull-request-ci-test.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-20.04
           - ubuntu-22.04
           - windows-latest
         include:
@@ -19,13 +20,14 @@ jobs:
             sm_branch: "1.11-dev"
             spcomp_version: "1.11.x"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             os_short: linux
-            package_ext: tar.gz
+
+          - os: ubuntu-22.04
+            os_short: newlinux
 
           - os: windows-latest
             os_short: win
-            package_ext: zip
 
     steps:
       - name: Prepare env


### PR DESCRIPTION
References https://github.com/nosoop/SMExt-SourceScramble/pull/19

This PR reverts the Ubuntu instance type used for releases from `22.04` to `20.04`. The reason is that there are still servers in the wild with `glibc` `2.31` (what Ubuntu 20.04 ships), and the resulting binaries from `glibc` `2.35` (what Ubuntu 22.04 ships) are not compatible.

SourceMod CI [tests PRs against both](https://github.com/alliedmodders/sourcemod/blob/ee51162c3fa7affaddd54a5f242e514d6f7c94ef/.github/workflows/ci.yml#L20-L27), but for releases it's probably better to link against `glib` `2.31` for now.