### PR TITLE
Improve gamedata validation

### DIFF
--- a/types/mempatch.cpp
+++ b/types/mempatch.cpp
@@ -55,7 +55,6 @@ public:
 				SH_MEM_READ | SH_MEM_WRITE | SH_MEM_EXEC);
 		ByteVectorWrite(vecPatch, (uint8_t*) pAddress);
 		
-		// 
 		for (size_t i = 0; i < vecPatch.size(); i++) {
 			uint8_t preserveBits = 0;
 			if (i < vecPreserve.size()) {
@@ -81,15 +80,20 @@ public:
 			return false;
 		}
 		
-		auto addr = (uint8_t*) pAddress;
-		for (size_t i = 0; i < this->vecVerify.size(); i++) {
-			if (vecVerify[i] != '*' && vecVerify[i] != addr[i]) {
+		auto addr = reinterpret_cast<uint8_t*>(pAddress);
+
+		for (size_t i = 0; i < vecVerify.size(); i++) {
+			// wildcard '*' skip
+			if (vecVerify[i] == static_cast<uint8_t>('*')) {
+				continue;
+			}
+
+			if (vecVerify[i] != addr[i]) {
 				return false;
 			}
 		}
 		return true;
 	}
-	
 	~MemoryPatch() {
 		this->Disable();
 	}
@@ -127,7 +131,6 @@ cell_t sm_MemoryPatchLoadFromConfig(IPluginContext *pContext, const cell_t *para
 	if (!pConfig) {
 		return pContext->ThrowNativeError("Invalid game config handle %x (error %d)", hndl, err);
 	}
-	
 	void* addr;
 	if (!pConfig->GetMemSig(info.signature.c_str(), &addr)) {
 		return pContext->ThrowNativeError("Failed to locate signature for '%s' (mempatch '%s')", info.signature.c_str(), name);
@@ -159,7 +162,6 @@ cell_t sm_MemoryPatchEnable(IPluginContext *pContext, const cell_t *params) {
 	if ((err = ReadMemoryPatchHandle(hndl, &pMemoryPatch)) != HandleError_None) {
 		return pContext->ThrowNativeError("Invalid MemoryPatch handle %x (error %d)", hndl, err);
 	}
-	
 	return pMemoryPatch->Enable();
 }
 

--- a/userconf/mempatches.h
+++ b/userconf/mempatches.h
@@ -20,6 +20,13 @@ public:
 public:
 	class MemoryPatchInfo {
 	public:
+		MemoryPatchInfo()
+		{
+			// Other class variables are themselves initialized with a default value, 
+			// but this one is not, it contains a garbage value
+			offset = 0;
+		}
+
 		std::string signature;
 		size_t offset;
 		ByteVector vecPatch, vecVerify, vecPreserve;


### PR DESCRIPTION
- Added stricter processing of game configuration data.
- Previously, the extension often returned no errors, even if some sections were
  incorrect, giving a false sense of successful patch application.
- Now, malformed sections or invalid entries trigger warnings or errors,
  making it clear when something is wrong.
- This helps prevent silent failures and speeds up development and testing
  by alerting users to typos or misconfigurations in the patch data.
- Fixed some type cast warnings.
- Ensured proper initialization of MemoryPatchInfo fields, avoiding uninitialized offset values.