### PR TITLE
Validate patch section and warn if patch bytes match binary

### DIFF
--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -40,7 +40,7 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"Source Scramble"
 #define SMEXT_CONF_DESCRIPTION	"Tools for working with memory."
-#define SMEXT_CONF_VERSION		"0.8.1"
+#define SMEXT_CONF_VERSION		"0.8.3"
 #define SMEXT_CONF_AUTHOR		"nosoop"
 #define SMEXT_CONF_URL			"https://github.com/nosoop/SMExt-SourceScramble"
 #define SMEXT_CONF_LOGTAG		"sscramble"

--- a/types/mempatch.cpp
+++ b/types/mempatch.cpp
@@ -37,61 +37,48 @@ public:
 		for (auto bit : info.vecPreserve) {
 			this->vecPreserve.push_back(bit);
 		}
-		
+
 		// ignore offset if address is bad
 		this->pAddress = pAddress ? pAddress + (info.offset) : 0;
-		strPatchName = info.patchName;
 	}
-	
+
 	bool Enable() {
 		if (vecRestore.size() > 0) {
 			// already patched, disregard
 			return false;
 		}
-		
+
 		if (!this->Verify()) {
 			return false;
 		}
 
-		if (std::equal(vecPatch.begin(), vecPatch.end(), (uint8_t*) pAddress)) {
-			// The bytes in the binary file already match the patch, 
-			// we inform the user that his patch is redundant, 
-			// we tell them to check the patch.
-			// In this case, as a rule, section `verify` is missing.
-			smutils->LogError(myself,
-				"Patch '%s' is redundant. Binary already contains the patch bytes. "
-				"Check patch data or perhaps it was applied by a different plugin?",
-				strPatchName.c_str()
-			);
-		}
+		ByteVectorRead(vecRestore, (uint8_t*)pAddress, vecPatch.size());
 
-		ByteVectorRead(vecRestore, (uint8_t*) pAddress, vecPatch.size());
-		
-		SourceHook::SetMemAccess((void*) this->pAddress, vecPatch.size() * sizeof(uint8_t),
-				SH_MEM_READ | SH_MEM_WRITE | SH_MEM_EXEC);
-		ByteVectorWrite(vecPatch, (uint8_t*) pAddress);
-		
+		SourceHook::SetMemAccess((void*)this->pAddress, vecPatch.size() * sizeof(uint8_t),
+			SH_MEM_READ | SH_MEM_WRITE | SH_MEM_EXEC);
+		ByteVectorWrite(vecPatch, (uint8_t*)pAddress);
+
 		for (size_t i = 0; i < vecPatch.size(); i++) {
 			uint8_t preserveBits = 0;
 			if (i < vecPreserve.size()) {
 				preserveBits = vecPreserve[i];
 			}
-			*((uint8_t*) pAddress + i) = (vecPatch[i] & ~preserveBits) | (vecRestore[i] & preserveBits);
+			*((uint8_t*)pAddress + i) = (vecPatch[i] & ~preserveBits) | (vecRestore[i] & preserveBits);
 		}
-		
+
 		return true;
 	}
-	
+
 	void Disable() {
 		if (vecRestore.size() == 0) {
 			// no memory to restore, fug
 			return;
 		}
 
-		ByteVectorWrite(vecRestore, (uint8_t*) pAddress);
+		ByteVectorWrite(vecRestore, (uint8_t*)pAddress);
 		vecRestore.clear();
 	}
-	
+
 	bool Verify() {
 		if (!pAddress) {
 			return false;
@@ -116,7 +103,6 @@ public:
 		this->Disable();
 	}
 
-	std::string strPatchName; // For error messages
 	uintptr_t pAddress;
 	ByteVector vecPatch, vecRestore, vecVerify, vecPreserve;
 };
@@ -150,13 +136,30 @@ cell_t sm_MemoryPatchLoadFromConfig(IPluginContext *pContext, const cell_t *para
 	if (!pConfig) {
 		return pContext->ThrowNativeError("Invalid game config handle %x (error %d)", hndl, err);
 	}
+
 	void* addr;
-	if (!pConfig->GetMemSig(info.signature.c_str(), &addr)) {
+	if (!pConfig->GetMemSig(info.signature.c_str(), &addr) || addr == NULL) {
 		return pContext->ThrowNativeError("Failed to locate signature for '%s' (mempatch '%s')", info.signature.c_str(), name);
 	}
-	
+
+	if (info.vecPatch.empty()) {
+		return pContext->ThrowNativeError("Invalid patch configuration: section `patch` is empty for patch '%s'", name);
+	}
+
+	if (std::equal(info.vecPatch.begin(), info.vecPatch.end(), (uint8_t*)addr)) {
+		// The bytes in the binary file already match the patch, 
+			// we inform the user that his patch is redundant, 
+			// we tell them to check the patch.
+			// In this case, as a rule, section `verify` is missing.
+		smutils->LogError(myself,
+			"Patch '%s' is redundant. Binary already contains the patch bytes. "
+			"Check patch data or perhaps it was applied by a different plugin?",
+			name
+		);
+	}
+
 	MemoryPatch *pMemoryPatch = new MemoryPatch((uintptr_t) addr, info);
-	
+
 	return g_pHandleSys->CreateHandle(g_MemoryPatchType, pMemoryPatch,
 			pContext->GetIdentity(), myself->GetIdentity(), NULL);
 }

--- a/types/mempatch.cpp
+++ b/types/mempatch.cpp
@@ -143,7 +143,7 @@ cell_t sm_MemoryPatchLoadFromConfig(IPluginContext *pContext, const cell_t *para
 	}
 
 	if (info.vecPatch.empty()) {
-		return pContext->ThrowNativeError("Invalid patch configuration: section `patch` is empty for patch '%s'", name);
+		return pContext->ThrowNativeError("Invalid patch configuration: section 'patch' is empty for patch '%s'", name);
 	}
 
 	if (std::equal(info.vecPatch.begin(), info.vecPatch.end(), (uint8_t*)addr)) {

--- a/userconf/mempatches.cpp
+++ b/userconf/mempatches.cpp
@@ -235,6 +235,10 @@ SMCResult MemPatchGameConfig::ReadSMC_LeavingSection(const SMCStates *states) {
 	case PState_Runtime:
 		// pop section info
 		g_ParseState = PState_Root;
+
+		// save data for error messages
+		g_CurrentPatchInfo->patchName = g_CurrentSection;
+
 		m_MemPatchInfoMap.insert(g_CurrentSection.c_str(), g_CurrentPatchInfo);
 		
 		g_CurrentPatchInfo = nullptr;

--- a/userconf/mempatches.cpp
+++ b/userconf/mempatches.cpp
@@ -235,10 +235,7 @@ SMCResult MemPatchGameConfig::ReadSMC_LeavingSection(const SMCStates *states) {
 	case PState_Runtime:
 		// pop section info
 		g_ParseState = PState_Root;
-
-		// save data for error messages
-		g_CurrentPatchInfo->patchName = g_CurrentSection;
-
+		
 		m_MemPatchInfoMap.insert(g_CurrentSection.c_str(), g_CurrentPatchInfo);
 		
 		g_CurrentPatchInfo = nullptr;

--- a/userconf/mempatches.h
+++ b/userconf/mempatches.h
@@ -27,7 +27,6 @@ public:
 			offset = 0;
 		}
 
-		std::string patchName;
 		std::string signature;
 		size_t offset;
 		ByteVector vecPatch, vecVerify, vecPreserve;

--- a/userconf/mempatches.h
+++ b/userconf/mempatches.h
@@ -27,6 +27,7 @@ public:
 			offset = 0;
 		}
 
+		std::string patchName;
 		std::string signature;
 		size_t offset;
 		ByteVector vecPatch, vecVerify, vecPreserve;


### PR DESCRIPTION
- Check that patch section is not empty; throw error if empty.
- Log warning if binary already contains patch bytes (redundant patch), without halting execution.

Fix #30